### PR TITLE
feat: support multiple clusters

### DIFF
--- a/docs/src/cn/SUMMARY.md
+++ b/docs/src/cn/SUMMARY.md
@@ -37,7 +37,7 @@
   - [系统表](operation/system_table.md)
   - [黑名单](operation/block_list.md)
   - [监控](operation/observability.md)
-  - [集群运维](operation/cluster.md)
+  - [CeresMeta](operation/ceresmeta.md)
 - [周边生态](ecosystem/README.md)
   - [Prometheus](ecosystem/prometheus.md)
   - [InfluxDB](ecosystem/influxdb.md)

--- a/docs/src/cn/operation/ceresmeta.md
+++ b/docs/src/cn/operation/ceresmeta.md
@@ -82,12 +82,12 @@ curl --location --request POST 'http://{CeresMetaAddr}:8080/api/v1/split' \
 - 创建 CeresDB 集群
 
 ```
-curl --location --request PUT 'http://{CeresMetaAddr}:8080/api/v1/createCluster' \
+curl --location 'http://{CeresMetaAddr}:8080/api/v1/clusters' \
 --header 'Content-Type: application/json' \
 --data '{
-    "clusterName":"testCluster",
-    "clusterNodeCount":3,
-    "clusterShardTotal":9,
+    "name":"testCluster",
+    "nodeCount":3,
+    "ShardTotal":9,
     "enableScheduler":true,
     "topologyType":"static"
 }'
@@ -96,10 +96,11 @@ curl --location --request PUT 'http://{CeresMetaAddr}:8080/api/v1/createCluster'
 - 更新 CeresDB 集群
 
 ```
-curl --location 'http://{CeresMetaAddr}:8080/api/v1/updateCluster' \
+curl --location --request PUT 'http://{CeresMetaAddr}:8080/api/v1/clusters/{NewClusterName}' \
 --header 'Content-Type: application/json' \
 --data '{
-    "clusterName":"testCluster",
+    "nodeCount":28,
+    "shardTotal":128,
     "enableSchedule":true,
     "topologyType":"dynamic"
 }'
@@ -108,5 +109,5 @@ curl --location 'http://{CeresMetaAddr}:8080/api/v1/updateCluster' \
 - 列出 CeresDB 集群
 
 ```
-curl --location 'http://{CeresMetaAddr}:8080/api/v1/listClusters'
+curl --location 'http://{CeresMetaAddr}:8080/api/v1/clusters'
 ```

--- a/docs/src/cn/operation/ceresmeta.md
+++ b/docs/src/cn/operation/ceresmeta.md
@@ -78,3 +78,35 @@ curl --location --request POST 'http://{CeresMetaAddr}:8080/api/v1/split' \
     "splitTables":["demo"]
 }'
 ```
+
+- 创建 CeresDB 集群
+
+```
+curl --location --request PUT 'http://{CeresMetaAddr}:8080/api/v1/createCluster' \
+--header 'Content-Type: application/json' \
+--data '{
+    "clusterName":"testCluster",
+    "clusterNodeCount":3,
+    "clusterShardTotal":9,
+    "enableScheduler":true,
+    "topologyType":"static"
+}'
+```
+
+- 更新 CeresDB 集群
+
+```
+curl --location 'http://{CeresMetaAddr}:8080/api/v1/updateCluster' \
+--header 'Content-Type: application/json' \
+--data '{
+    "clusterName":"testCluster",
+    "enableSchedule":true,
+    "topologyType":"dynamic"
+}'
+```
+
+- 列出 CeresDB 集群
+
+```
+curl --location 'http://{CeresMetaAddr}:8080/api/v1/listClusters'
+```

--- a/docs/src/en/SUMMARY.md
+++ b/docs/src/en/SUMMARY.md
@@ -37,7 +37,7 @@
   - [System Table](operation/system_table.md)
   - [Block List](operation/block_list.md)
   - [Observability](operation/observability.md)
-  - [Cluster](operation/cluster.md)
+  - [CeresMeta](operation/ceresmeta.md)
 - [Ecosystem](ecosystem/README.md)
   - [Prometheus](ecosystem/prometheus.md)
   - [InfluxDB](ecosystem/influxdb.md)

--- a/docs/src/en/operation/ceresmeta.md
+++ b/docs/src/en/operation/ceresmeta.md
@@ -78,3 +78,35 @@ curl --location --request POST 'http://{CeresMetaAddr}:8080/api/v1/split' \
     "splitTables":["demo"]
 }'
 ```
+
+- Create cluster
+
+```
+curl --location --request PUT 'http://{CeresMetaAddr}:8080/api/v1/createCluster' \
+--header 'Content-Type: application/json' \
+--data '{
+    "clusterName":"testCluster",
+    "clusterNodeCount":3,
+    "clusterShardTotal":9,
+    "enableScheduler":true,
+    "topologyType":"static"
+}'
+```
+
+- Update cluster
+
+```
+curl --location 'http://{CeresMetaAddr}:8080/api/v1/updateCluster' \
+--header 'Content-Type: application/json' \
+--data '{
+    "clusterName":"testCluster",
+    "enableSchedule":true,
+    "topologyType":"dynamic"
+}'
+```
+
+- list clusters
+
+```
+curl --location 'http://{CeresMetaAddr}:8080/api/v1/listClusters'
+```

--- a/docs/src/en/operation/ceresmeta.md
+++ b/docs/src/en/operation/ceresmeta.md
@@ -82,12 +82,12 @@ curl --location --request POST 'http://{CeresMetaAddr}:8080/api/v1/split' \
 - Create cluster
 
 ```
-curl --location --request PUT 'http://{CeresMetaAddr}:8080/api/v1/createCluster' \
+curl --location 'http://{CeresMetaAddr}:8080/api/v1/clusters' \
 --header 'Content-Type: application/json' \
 --data '{
-    "clusterName":"testCluster",
-    "clusterNodeCount":3,
-    "clusterShardTotal":9,
+    "name":"testCluster",
+    "nodeCount":3,
+    "shardTotal":9,
     "enableScheduler":true,
     "topologyType":"static"
 }'
@@ -96,10 +96,11 @@ curl --location --request PUT 'http://{CeresMetaAddr}:8080/api/v1/createCluster'
 - Update cluster
 
 ```
-curl --location 'http://{CeresMetaAddr}:8080/api/v1/updateCluster' \
+curl --location --request PUT 'http://{CeresMetaAddr}:8080/api/v1/clusters/{NewClusterName}' \
 --header 'Content-Type: application/json' \
 --data '{
-    "clusterName":"testCluster",
+    "nodeCount":28,
+    "shardTotal":128,
     "enableSchedule":true,
     "topologyType":"dynamic"
 }'
@@ -108,5 +109,5 @@ curl --location 'http://{CeresMetaAddr}:8080/api/v1/updateCluster' \
 - list clusters
 
 ```
-curl --location 'http://{CeresMetaAddr}:8080/api/v1/listClusters'
+curl --location 'http://{CeresMetaAddr}:8080/api/v1/clusters'
 ```


### PR DESCRIPTION
Currently, one CeresMeta cluster is supported to manage multiple CeresDB clusters, and the operation interface documentation is supplemented.